### PR TITLE
Adding Pylint for PEP8 Standards and CODEOWNERS for Pull Request Approvals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @adambonneruk

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,7 +17,7 @@ This project welcomes contributions of all types. Please feel welcome to get inv
 - Try to follow the "one-file-per-commit" rule
 
 ## Actions
-- No actions are used by this repository
+- There is a Github workflow which is triggered on a Pull Request that runs `pylint` (a Python Static Code Analyser) to ensure code conforms to the PEP8 standards
 
 ## Projects
 - No Projects are used by this repository

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,26 @@
+name: "Pyradials CI"
+
+on:
+  workflow_dispatch: null
+  push:
+    branches:
+      - develop
+      - main
+  pull_request:
+
+jobs:
+  QA:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
+    - name: Setup Pylint
+      run: pip install pylint
+      shell: bash
+    - name: Run Pylint
+      id: checks
+      run: pylint --fail-under=8 $(git ls-files '*.py')
+      shell: bash

--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ pyinstaller 'pyradials/pyradials.spec' --noconfirm
 makensis 'installer/pyradials.nsi'
 ```
 
+## CI
+There is a Github workflow which is triggered on a Pull Request that runs `pylint` (a Python Static Code Analyser) to ensure code conforms to the PEP8 standard.
+
 ## Contributing to this Project
 This project welcomes contributions of all types. We ask that before you start work on a feature that you would like to contribute, please read the [Contributor's Guide](.github/CONTRIBUTING.md).
 


### PR DESCRIPTION
This PR includes adding a CODEOWNERS for PR requests as well as a pipeline to run linting checks against pyradials code.

Suggestions to leverage CODEOWNERS and pipeline:

- Create a protected branch rule for `main` and `develop` to require a Pull Request before merging
- Pull Request should require approval from CODEOWNERS as well as status check (pylinting) to pass before merging
- **Enable Github Actions in repository settings**